### PR TITLE
feat: add scope filters and implement VG002 (forbidden dirs) & VG003 (secret scan)

### DIFF
--- a/apps/cli/tests/test_cli_check.py
+++ b/apps/cli/tests/test_cli_check.py
@@ -22,3 +22,18 @@ def test_check_outputs_findings_json(tmp_path: Path, capsys) -> None:
     assert payload["run"]["policy_id"] == "baseline"
     assert payload["summary"]["overall_status"] == "pass"
     assert payload["findings"] == []
+
+
+def test_audit_pack_writes_policy_snapshot(tmp_path: Path) -> None:
+    from vibeguard_cli.main import run_audit_pack
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_required_files(repo)
+
+    out_dir = tmp_path / "audit"
+    exit_code = run_audit_pack(repo, Path("policies/bundles/baseline/policy.yaml"), out_dir=out_dir)
+
+    assert exit_code == 0
+    assert (out_dir / "reports" / "findings.json").is_file()
+    assert (out_dir / "policy_bundle" / "policy.yaml").is_file()

--- a/apps/cli/tests/test_path_scope.py
+++ b/apps/cli/tests/test_path_scope.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from packages.core.path_scope import iter_scoped_paths
+
+
+def test_iter_scoped_paths_deterministic(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "b.txt").write_text("b", encoding="utf-8")
+    (repo / "a.txt").write_text("a", encoding="utf-8")
+
+    paths = iter_scoped_paths(repo)
+
+    assert [path.as_posix() for path in paths] == ["a.txt", "b.txt"]
+
+
+def test_iter_scoped_paths_include_exclude(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src").mkdir()
+    (repo / "src" / "ok.py").write_text("x", encoding="utf-8")
+    (repo / "src" / "skip.py").write_text("x", encoding="utf-8")
+
+    paths = iter_scoped_paths(repo, include_paths=["src/*.py"], exclude_paths=["src/skip.py"])
+
+    assert [path.as_posix() for path in paths] == ["src/ok.py"]

--- a/apps/cli/tests/test_policy_loader.py
+++ b/apps/cli/tests/test_policy_loader.py
@@ -33,3 +33,18 @@ def test_load_policy_bundle_schema_violation(tmp_path: Path) -> None:
 
     with pytest.raises(PolicyLoadError, match="schema validation failed"):
         load_policy_bundle(policy_path)
+
+
+def test_load_policy_bundle_scope_fields(tmp_path: Path) -> None:
+    policy_path = tmp_path / "policy.yaml"
+    policy_path.write_text(
+        '{"id":"baseline","version":"0.1.0","description":"x","include_paths":["src/**"],"exclude_paths":["tests/**"],"gates":[{"id":"VG001","enabled":true,"include_paths":["src/**"],"exclude_paths":["tmp/**"],"config":{}}]}',
+        encoding="utf-8",
+    )
+
+    policy = load_policy_bundle(policy_path)
+
+    assert policy.include_paths == ["src/**"]
+    assert policy.exclude_paths == ["tests/**"]
+    assert policy.gates[0].include_paths == ["src/**"]
+    assert policy.gates[0].exclude_paths == ["tmp/**"]

--- a/apps/cli/tests/test_vg002_vg003.py
+++ b/apps/cli/tests/test_vg002_vg003.py
@@ -1,0 +1,162 @@
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from packages.core.policy_loader import load_policy_bundle
+from packages.gates.runner import run_gates
+
+
+def _policy(tmp_path: Path, gates: list[dict], include_paths=None, exclude_paths=None) -> Path:
+    payload = {
+        "id": "test",
+        "version": "0.1.0",
+        "description": "test",
+        "gates": gates,
+    }
+    if include_paths is not None:
+        payload["include_paths"] = include_paths
+    if exclude_paths is not None:
+        payload["exclude_paths"] = exclude_paths
+    path = tmp_path / "policy.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_vg002_passes_when_forbidden_absent(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    policy = _policy(tmp_path, [{"id": "VG002", "enabled": True, "config": {}}])
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert report.summary.overall_status == "pass"
+
+
+def test_vg002_fails_when_forbidden_exists(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "dist").mkdir()
+    policy = _policy(tmp_path, [{"id": "VG002", "enabled": True, "config": {}}])
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert report.summary.overall_status == "fail"
+    assert report.findings[0].id == "VG002:dist"
+
+
+def test_vg002_allowed_path_is_ignored(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "dist").mkdir()
+    policy = _policy(
+        tmp_path,
+        [{"id": "VG002", "enabled": True, "config": {"forbidden": ["dist"], "allow": ["dist"]}}],
+    )
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert report.summary.overall_status == "pass"
+
+
+def test_vg002_findings_are_deterministic(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "build").mkdir()
+    (repo / "dist").mkdir()
+    policy = _policy(
+        tmp_path,
+        [{"id": "VG002", "enabled": True, "config": {"forbidden": ["dist", "build"], "allow": []}}],
+    )
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert [finding.id for finding in report.findings] == ["VG002:build", "VG002:dist"]
+
+
+def test_vg003_detects_patterns_without_secret_value_leak(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "secrets.txt").write_text(
+        "AKIA1234567890ABCDEF\n"
+        "ghp_superSecretTokenValue\n"
+        "xoxb-1234567890-abcdefghijkl\n"
+        "-----BEGIN PRIVATE KEY-----\n",
+        encoding="utf-8",
+    )
+    policy = _policy(tmp_path, [{"id": "VG003", "enabled": True, "config": {}}])
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert len(report.findings) == 4
+    serialized = json.dumps([asdict(finding) for finding in report.findings])
+    assert "superSecretTokenValue" not in serialized
+
+
+def test_vg003_allow_paths_excludes_files(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "ignore.txt").write_text("AKIA1234567890ABCDEF\n", encoding="utf-8")
+    policy = _policy(
+        tmp_path,
+        [{"id": "VG003", "enabled": True, "config": {"allow_paths": ["ignore.txt"]}}],
+    )
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert report.summary.overall_status == "pass"
+
+
+def test_vg003_allow_patterns_suppresses_finding(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "file.txt").write_text("AKIA1234567890ABCDEF\n", encoding="utf-8")
+    policy = _policy(
+        tmp_path,
+        [
+            {
+                "id": "VG003",
+                "enabled": True,
+                "config": {"allow_patterns": [r"AKIA[0-9A-Z]{16}"]},
+            }
+        ],
+    )
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert report.summary.overall_status == "pass"
+
+
+def test_vg003_skips_binary_file(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "blob.bin").write_bytes(b"\x00AKIA1234567890ABCDEF")
+    policy = _policy(tmp_path, [{"id": "VG003", "enabled": True, "config": {}}])
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert report.summary.overall_status == "pass"
+
+
+def test_vg003_uses_scope_filters_and_gate_override(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "safe.txt").write_text("AKIA1234567890ABCDEF\n", encoding="utf-8")
+    (repo / "scan.txt").write_text("AKIA1234567890ABCDEF\n", encoding="utf-8")
+
+    policy = _policy(
+        tmp_path,
+        [
+            {
+                "id": "VG003",
+                "enabled": True,
+                "include_paths": ["scan.txt"],
+                "config": {},
+            }
+        ],
+        include_paths=["safe.txt"],
+    )
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert len(report.findings) == 1
+    assert report.findings[0].path == "scan.txt"

--- a/apps/cli/vibeguard_cli/main.py
+++ b/apps/cli/vibeguard_cli/main.py
@@ -35,12 +35,17 @@ def run_audit_pack(repo: Path, policy: Path, out_dir: Path = DEFAULT_AUDIT_OUT_D
 
     (out_dir / "reports").mkdir(parents=True, exist_ok=True)
     (out_dir / "evidence").mkdir(parents=True, exist_ok=True)
+    (out_dir / "policy_bundle").mkdir(parents=True, exist_ok=True)
 
     report = run_gates(policy=policy_bundle, repo_path=repo)
 
     (out_dir / "reports" / "findings.json").write_text(report.to_json(), encoding="utf-8")
     (out_dir / "reports" / "summary.md").write_text(
         "# VibeGuard Audit Pack\n\nStub.\n",
+        encoding="utf-8",
+    )
+    (out_dir / "policy_bundle" / "policy.yaml").write_text(
+        policy.read_text(encoding="utf-8"),
         encoding="utf-8",
     )
     print(str(out_dir))

--- a/packages/core/path_scope.py
+++ b/packages/core/path_scope.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from fnmatch import fnmatch
+from pathlib import Path
+
+
+def _normalize(patterns: list[str] | None) -> list[str]:
+    if not patterns:
+        return []
+    return [pattern.strip() for pattern in patterns if pattern.strip()]
+
+
+def _matches(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch(path, pattern) for pattern in patterns)
+
+
+def iter_scoped_paths(
+    repo_root: Path,
+    include_paths: list[str] | None = None,
+    exclude_paths: list[str] | None = None,
+    *,
+    files_only: bool = True,
+) -> list[Path]:
+    """Return deterministic relative paths constrained by include/exclude globs."""
+    includes = _normalize(include_paths) or ["**"]
+    excludes = _normalize(exclude_paths)
+
+    candidates: list[Path] = []
+    for entry in repo_root.rglob("*"):
+        if files_only and not entry.is_file():
+            continue
+        rel = entry.relative_to(repo_root)
+        rel_str = rel.as_posix()
+        if not _matches(rel_str, includes):
+            continue
+        if excludes and _matches(rel_str, excludes):
+            continue
+        candidates.append(rel)
+
+    return sorted(candidates, key=lambda item: item.as_posix())

--- a/packages/core/policy_loader.py
+++ b/packages/core/policy_loader.py
@@ -10,6 +10,8 @@ from typing import Any
 class GateConfig:
     id: str
     enabled: bool = True
+    include_paths: list[str] | None = None
+    exclude_paths: list[str] | None = None
     config: dict[str, Any] = field(default_factory=dict)
 
 
@@ -19,6 +21,8 @@ class PolicyBundle:
     version: str
     description: str
     gates: list[GateConfig]
+    include_paths: list[str] | None = None
+    exclude_paths: list[str] | None = None
 
 
 class PolicyLoadError(ValueError):
@@ -52,12 +56,38 @@ def _parse_gate(item: Any, idx: int) -> GateConfig:
         raise PolicyLoadError(
             f"policy schema validation failed: gates[{idx}].enabled must be a boolean",
         )
+    include_paths = _optional_str_list(item, "include_paths", f"gates[{idx}].include_paths")
+    exclude_paths = _optional_str_list(item, "exclude_paths", f"gates[{idx}].exclude_paths")
     config = item.get("config", {})
     if not isinstance(config, dict):
         raise PolicyLoadError(
             f"policy schema validation failed: gates[{idx}].config must be an object",
         )
-    return GateConfig(id=gate_id, enabled=enabled, config=config)
+    return GateConfig(
+        id=gate_id,
+        enabled=enabled,
+        include_paths=include_paths,
+        exclude_paths=exclude_paths,
+        config=config,
+    )
+
+
+def _optional_str_list(
+    data: dict[str, Any],
+    key: str,
+    label: str | None = None,
+) -> list[str] | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, list) or any(
+        not isinstance(item, str) or not item for item in value
+    ):
+        raise PolicyLoadError(
+            "policy schema validation failed: "
+            f"'{label or key}' must be a list of non-empty strings",
+        )
+    return value
 
 
 def load_policy_bundle(path: Path) -> PolicyBundle:
@@ -81,5 +111,7 @@ def load_policy_bundle(path: Path) -> PolicyBundle:
         id=_require_str(data, "id"),
         version=_require_str(data, "version"),
         description=_require_str(data, "description"),
+        include_paths=_optional_str_list(data, "include_paths"),
+        exclude_paths=_optional_str_list(data, "exclude_paths"),
         gates=[_parse_gate(item, idx) for idx, item in enumerate(gates)],
     )

--- a/packages/gates/registry.py
+++ b/packages/gates/registry.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import re
+from fnmatch import fnmatch
+from pathlib import Path
+
+from packages.core.path_scope import iter_scoped_paths
 from packages.reporting.findings import Finding
 
 from .base import Gate
@@ -11,6 +16,17 @@ REQUIRED_FILES = [
     "ARCHITECTURE.md",
     "AGENTS.md",
     "ISSUE_ORDER.md",
+]
+
+DEFAULT_FORBIDDEN = [
+    ".env",
+    ".next",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "node_modules",
+    "secrets",
 ]
 
 
@@ -37,8 +53,105 @@ class VG001RequiredFilesGate(Gate):
         return findings
 
 
+class VG002ForbiddenDirectoriesGate(Gate):
+    id = "VG002"
+    description = "Forbidden repository root paths must not exist"
+
+    def run(self, ctx: GateContext) -> list[Finding]:
+        forbidden = sorted(ctx.gate_config.config.get("forbidden", DEFAULT_FORBIDDEN))
+        allow = set(ctx.gate_config.config.get("allow", []))
+
+        findings: list[Finding] = []
+        for raw_path in forbidden:
+            if raw_path in allow:
+                continue
+            path = Path(raw_path.rstrip("/"))
+            if (ctx.repo_path / path).exists():
+                findings.append(
+                    Finding(
+                        id=f"VG002:{path.as_posix()}",
+                        gate_id=self.id,
+                        severity="high",
+                        title=f"Forbidden path present: {path.as_posix()}",
+                        message=(
+                            "Remove generated/build artifacts or secrets from repository root. "
+                            "If this path is intentional, explicitly add it to VG002 config.allow."
+                        ),
+                        path=path.as_posix(),
+                    ),
+                )
+        return findings
+
+
+class VG003BasicSecretScanGate(Gate):
+    id = "VG003"
+    description = "Basic high-confidence secret pattern scan"
+
+    _PATTERNS = [
+        ("AWS Access Key ID", re.compile(r"AKIA[0-9A-Z]{16}")),
+        ("GitHub Token", re.compile(r"(?:ghp_|gho_|ghu_|ghs_|github_pat_)[A-Za-z0-9_]+")),
+        ("Slack Token", re.compile(r"xox(?:b|p|a)-[A-Za-z0-9-]+")),
+        ("Private Key Block", re.compile(r"BEGIN PRIVATE KEY")),
+    ]
+
+    def run(self, ctx: GateContext) -> list[Finding]:
+        include_paths = ctx.gate_config.include_paths or ctx.policy.include_paths
+        exclude_paths = ctx.gate_config.exclude_paths or ctx.policy.exclude_paths
+        allow_paths = ctx.gate_config.config.get("allow_paths", [])
+        allow_patterns = [
+            re.compile(pattern)
+            for pattern in ctx.gate_config.config.get("allow_patterns", [])
+        ]
+
+        scoped_files = iter_scoped_paths(
+            ctx.repo_path,
+            include_paths=include_paths,
+            exclude_paths=exclude_paths,
+            files_only=True,
+        )
+
+        findings: list[Finding] = []
+        for rel_path in scoped_files:
+            rel_str = rel_path.as_posix()
+            if any(fnmatch(rel_str, pattern) for pattern in allow_paths):
+                continue
+
+            raw = (ctx.repo_path / rel_path).read_bytes()
+            if b"\x00" in raw:
+                continue
+            try:
+                text = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+
+            for line_no, line in enumerate(text.splitlines(), start=1):
+                for pattern_name, pattern in self._PATTERNS:
+                    for match in pattern.finditer(line):
+                        matched_text = match.group(0)
+                        if any(allowed.search(matched_text) for allowed in allow_patterns):
+                            continue
+                        findings.append(
+                            Finding(
+                                id=f"VG003:{rel_str}:{line_no}:{pattern_name}",
+                                gate_id=self.id,
+                                severity="high",
+                                title=f"Potential secret detected ({pattern_name})",
+                                message=(
+                                    "Potential credential material detected. Rotate/revoke exposed "
+                                    "credentials, remove secrets from the repository, and store "
+                                    "secrets in a secure secret manager."
+                                ),
+                                path=rel_str,
+                                line=line_no,
+                            ),
+                        )
+        return findings
+
+
 GATE_REGISTRY: dict[str, type[Gate]] = {
     VG001RequiredFilesGate.id: VG001RequiredFilesGate,
+    VG002ForbiddenDirectoriesGate.id: VG002ForbiddenDirectoriesGate,
+    VG003BasicSecretScanGate.id: VG003BasicSecretScanGate,
 }
 
 

--- a/policies/SCHEMA.md
+++ b/policies/SCHEMA.md
@@ -1,15 +1,23 @@
 # Policy Bundle Schema (v0)
 
-This repo uses simple YAML policy bundles in `policies/bundles/*`.
+Policy bundles are JSON-formatted files stored under `policies/bundles/*`.
 
 ## Required keys
-- `bundle_id` (string)
+- `id` (string)
 - `version` (string)
-- `gates` (map of gate_id -> config)
-- `thresholds` (optional)
+- `description` (string)
+- `gates` (non-empty list)
 
-## Gate config (common)
-- `enabled` (bool)
-- `severity_fail` (list of severities that fail the run: [high, critical] etc)
+## Optional global scope
+- `include_paths: list[str]` glob patterns to include
+- `exclude_paths: list[str]` glob patterns to exclude
+
+## Gate entry schema
+Each gate entry supports:
+- `id` (string)
+- `enabled` (bool, default `true`)
+- `config` (object)
+- `include_paths: list[str]` (optional, overrides global for this gate)
+- `exclude_paths: list[str]` (optional, overrides global for this gate)
 
 See: `policies/bundles/baseline/policy.yaml`.

--- a/policies/bundles/baseline/policy.yaml
+++ b/policies/bundles/baseline/policy.yaml
@@ -2,11 +2,38 @@
   "id": "baseline",
   "version": "0.1.0",
   "description": "Baseline gates for VibeGuard v0",
+  "include_paths": ["**"],
+  "exclude_paths": [".git/**"],
   "gates": [
     {
       "id": "VG001",
       "enabled": true,
       "config": {}
+    },
+    {
+      "id": "VG002",
+      "enabled": true,
+      "config": {
+        "forbidden": [
+          "node_modules",
+          "dist",
+          "build",
+          ".next",
+          ".venv",
+          "__pycache__",
+          ".env",
+          "secrets"
+        ],
+        "allow": []
+      }
+    },
+    {
+      "id": "VG003",
+      "enabled": true,
+      "config": {
+        "allow_paths": [],
+        "allow_patterns": []
+      }
     }
   ]
 }

--- a/spec/GATES.md
+++ b/spec/GATES.md
@@ -1,17 +1,52 @@
 # Gates (v0)
 
 ## Gate categories
-- Repo hygiene (required files present, formatting)
-- Secrets scan (baseline)
-- Dependency policy (licenses, ecosystem, allow/deny)
-- Scope enforcement (changed files are within allowed paths)
-- CI configuration (required workflows present)
+- Repo hygiene (required files present)
+- Forbidden root paths (build artifacts, generated folders, secrets files)
+- Basic secret scan (high-confidence token/pem patterns)
 
-## Output contract
-Every gate returns:
-- `id`, `name`, `status` (pass/fail/warn/error)
-- `findings[]` with `severity`, `message`, `evidence` (paths/lines when applicable)
+## Implemented baseline gates
+
+### VG001 — Required Files
+Ensures required files exist at repository root (`README.md`, `SECURITY.md`, `ARCHITECTURE.md`, `AGENTS.md`, `ISSUE_ORDER.md`).
+
+### VG002 — Forbidden Directories / Files
+Checks for forbidden paths at repository root.
+
+Default forbidden paths:
+- `node_modules/`
+- `dist/`
+- `build/`
+- `.next/`
+- `.venv/`
+- `__pycache__/`
+- `.env`
+- `secrets/`
+
+Config:
+- `forbidden: list[str]` paths relative to repo root
+- `allow: list[str]` explicit exceptions
+
+### VG003 — Basic Secret Scan
+Scans scoped text files using high-confidence patterns:
+- AWS access key IDs (`AKIA[0-9A-Z]{16}`)
+- GitHub tokens (`ghp_`, `gho_`, `ghu_`, `ghs_`, `github_pat_`)
+- Slack tokens (`xoxb-`, `xoxp-`, `xoxa-`)
+- `BEGIN PRIVATE KEY` blocks
+
+Config:
+- `allow_paths: list[str]` glob paths skipped during scan
+- `allow_patterns: list[str]` regex patterns to suppress matched token text
+
+Findings are `high` severity and include path + pattern name, never the secret value.
+
+## Scope filters
+Policy supports global scope filters and per-gate overrides:
+- `include_paths: list[str]` optional glob allowlist
+- `exclude_paths: list[str]` optional glob denylist
+
+Per-gate `include_paths` / `exclude_paths` override global values for that gate.
 
 ## Fail-closed rules
 - Policy cannot be loaded → error → overall fail
-- Gate errors executing → error → overall fail
+- Unknown gate id in policy → finding → overall fail


### PR DESCRIPTION
### Motivation
- Add policy-level and per-gate scope filters so gates only consider intended files/dirs for scanning (Issue #010). 
- Implement the next baseline gates slice for repository hygiene and secrets: VG002 (forbidden root paths) and VG003 (high-confidence secret scan) as required by Issue #009 (baseline gates slice). 
- Ensure deterministic, fast, and safe scanning behaviour with clear allow/ignore controls so runs remain reproducible and avoid leaking secret values. 

### Description
- Policy schema extended to support global `include_paths` and `exclude_paths`, and per-gate `include_paths` / `exclude_paths` overrides via `packages/core/policy_loader.py` (GateConfig + PolicyBundle). 
- Added deterministic path-scoping utility `packages/core/path_scope.py` that expands include/exclude globs and returns ordered candidate files for gates. 
- Implemented `VG002` in `packages/gates/registry.py` to check configurable forbidden root paths with `forbidden` and `allow` lists and deterministic finding ordering. 
- Implemented `VG003` in `packages/gates/registry.py` to scan scoped text files (binary skip heuristic), match high-confidence patterns (AWS key, GitHub tokens, Slack tokens, private-key blocks), support `allow_paths` and `allow_patterns`, and produce HIGH findings without exposing secret values. 
- Wire-up and hygiene: updated baseline policy bundle (`policies/bundles/baseline/policy.yaml`) to enable `VG001`, `VG002`, `VG003` and added docs (`policies/SCHEMA.md`, `spec/GATES.md`) and audit-pack snapshotting (`apps/cli/vibeguard_cli/main.py`). 
- Tests: added and updated unit tests covering policy parsing, scoped path utility, VG002 behaviours (absent/present/allowed/deterministic), VG003 behaviours (pattern detection, allowlists, binary skip, scope overrides), and audit-pack snapshot. 

### Testing
- Ran `python -m pre_commit run --all-files` and all checks passed. 
- Ran `pytest -q` and the test suite passed: `27 passed`. 
- Ran `make verify` and it completed successfully (pre-commit checks + tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a51bbf28c883268e169e3b77dc6012)