### PR TITLE
v0.1: VG004 license check + VG005 CI workflow presence

### DIFF
--- a/apps/cli/tests/test_cli_check.py
+++ b/apps/cli/tests/test_cli_check.py
@@ -7,6 +7,10 @@ from vibeguard_cli.main import run_check
 def _write_required_files(repo: Path) -> None:
     for file_name in ["README.md", "SECURITY.md", "ARCHITECTURE.md", "AGENTS.md", "ISSUE_ORDER.md"]:
         (repo / file_name).write_text("ok\n", encoding="utf-8")
+    (repo / "LICENSE").write_text("MIT\n", encoding="utf-8")
+    workflow_dir = repo / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    (workflow_dir / "verify.yml").write_text("name: verify\n", encoding="utf-8")
 
 
 def test_check_outputs_findings_json(tmp_path: Path, capsys) -> None:

--- a/apps/cli/tests/test_gate_runner.py
+++ b/apps/cli/tests/test_gate_runner.py
@@ -10,6 +10,10 @@ REQUIRED_FILES = ["README.md", "SECURITY.md", "ARCHITECTURE.md", "AGENTS.md", "I
 def _write_required_files(repo: Path) -> None:
     for file_name in REQUIRED_FILES:
         (repo / file_name).write_text("ok\n", encoding="utf-8")
+    (repo / "LICENSE").write_text("MIT\n", encoding="utf-8")
+    workflow_dir = repo / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    (workflow_dir / "verify.yml").write_text("name: verify\n", encoding="utf-8")
 
 
 def test_unknown_gate_fails_closed(tmp_path: Path) -> None:

--- a/apps/cli/tests/test_vg004_vg005.py
+++ b/apps/cli/tests/test_vg004_vg005.py
@@ -1,0 +1,141 @@
+import json
+from pathlib import Path
+
+from packages.core.policy_loader import load_policy_bundle
+from packages.gates.runner import run_gates
+
+
+def _policy(tmp_path: Path, gates: list[dict]) -> Path:
+    payload = {
+        "id": "test",
+        "version": "0.1.0",
+        "description": "test",
+        "gates": gates,
+    }
+    path = tmp_path / "policy.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_vg004_passes_when_license_exists(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "LICENSE").write_text("MIT\n", encoding="utf-8")
+    policy = _policy(tmp_path, [{"id": "VG004", "enabled": True, "config": {}}])
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert report.summary.overall_status == "pass"
+
+
+def test_vg004_fails_when_license_missing_and_required(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    policy = _policy(tmp_path, [{"id": "VG004", "enabled": True, "config": {}}])
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert report.summary.overall_status == "fail"
+    assert [finding.id for finding in report.findings] == ["VG004:license"]
+
+
+def test_vg004_passes_when_notices_missing_but_not_required(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "LICENSE").write_text("MIT\n", encoding="utf-8")
+    policy = _policy(tmp_path, [{"id": "VG004", "enabled": True, "config": {}}])
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert report.summary.overall_status == "pass"
+
+
+def test_vg004_fails_when_notices_required_and_missing(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "LICENSE").write_text("MIT\n", encoding="utf-8")
+    policy = _policy(
+        tmp_path,
+        [
+            {
+                "id": "VG004",
+                "enabled": True,
+                "config": {"require_third_party_notices": True},
+            }
+        ],
+    )
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert report.summary.overall_status == "fail"
+    assert [finding.id for finding in report.findings] == ["VG004:third-party-notices"]
+
+
+def test_vg004_findings_order_is_deterministic(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    policy = _policy(
+        tmp_path,
+        [
+            {
+                "id": "VG004",
+                "enabled": True,
+                "config": {
+                    "require_license": True,
+                    "require_third_party_notices": True,
+                },
+            }
+        ],
+    )
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert [finding.id for finding in report.findings] == [
+        "VG004:license",
+        "VG004:third-party-notices",
+    ]
+
+
+def test_vg005_passes_when_verify_workflow_exists(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    workflow_dir = repo / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "verify.yml").write_text("name: verify\n", encoding="utf-8")
+    policy = _policy(tmp_path, [{"id": "VG005", "enabled": True, "config": {}}])
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert report.summary.overall_status == "pass"
+
+
+def test_vg005_fails_when_required_workflow_missing(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    policy = _policy(tmp_path, [{"id": "VG005", "enabled": True, "config": {}}])
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert report.summary.overall_status == "fail"
+    assert report.findings[0].id == "VG005:required-workflows"
+    assert ".github/workflows/verify.yml" in report.findings[0].message
+
+
+def test_vg005_required_workflows_override(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "ci.yaml").write_text("name: ci\n", encoding="utf-8")
+    policy = _policy(
+        tmp_path,
+        [
+            {
+                "id": "VG005",
+                "enabled": True,
+                "config": {"required_workflows": ["ci.yaml"]},
+            }
+        ],
+    )
+
+    report = run_gates(load_policy_bundle(policy), repo)
+
+    assert report.summary.overall_status == "pass"

--- a/packages/gates/registry.py
+++ b/packages/gates/registry.py
@@ -29,6 +29,10 @@ DEFAULT_FORBIDDEN = [
     "secrets",
 ]
 
+DEFAULT_LICENSE_PATHS = ["LICENSE", "LICENSE.md", "LICENSE.txt"]
+DEFAULT_NOTICES_PATHS = ["THIRD_PARTY_NOTICES.md", "THIRD_PARTY_NOTICES.txt"]
+DEFAULT_REQUIRED_WORKFLOWS = [".github/workflows/verify.yml"]
+
 
 class VG001RequiredFilesGate(Gate):
     id = "VG001"
@@ -148,10 +152,85 @@ class VG003BasicSecretScanGate(Gate):
         return findings
 
 
+class VG004LicenseAndNoticesGate(Gate):
+    id = "VG004"
+    description = "Repository license and third-party notices presence"
+
+    def run(self, ctx: GateContext) -> list[Finding]:
+        require_license = ctx.gate_config.config.get("require_license", True)
+        require_notices = ctx.gate_config.config.get("require_third_party_notices", False)
+        license_paths = ctx.gate_config.config.get("license_paths", DEFAULT_LICENSE_PATHS)
+        notices_paths = ctx.gate_config.config.get("notices_paths", DEFAULT_NOTICES_PATHS)
+
+        findings: list[Finding] = []
+
+        if require_license and not any((ctx.repo_path / path).is_file() for path in license_paths):
+            findings.append(
+                Finding(
+                    id="VG004:license",
+                    gate_id=self.id,
+                    severity="high",
+                    title="Missing repository license file",
+                    message=(
+                        "Add a repository license file at one of the configured paths "
+                        f"({', '.join(license_paths)})."
+                    ),
+                    path=license_paths[0],
+                ),
+            )
+
+        if require_notices and not any((ctx.repo_path / path).is_file() for path in notices_paths):
+            findings.append(
+                Finding(
+                    id="VG004:third-party-notices",
+                    gate_id=self.id,
+                    severity="high",
+                    title="Missing third-party notices file",
+                    message=(
+                        "Add third-party notices at one of the configured paths "
+                        f"({', '.join(notices_paths)})."
+                    ),
+                    path=notices_paths[0],
+                ),
+            )
+
+        return findings
+
+
+class VG005RequiredWorkflowsGate(Gate):
+    id = "VG005"
+    description = "Required CI workflow files must exist"
+
+    def run(self, ctx: GateContext) -> list[Finding]:
+        required_workflows = ctx.gate_config.config.get(
+            "required_workflows",
+            DEFAULT_REQUIRED_WORKFLOWS,
+        )
+        missing = [path for path in required_workflows if not (ctx.repo_path / path).is_file()]
+        if not missing:
+            return []
+
+        return [
+            Finding(
+                id="VG005:required-workflows",
+                gate_id=self.id,
+                severity="high",
+                title="Missing required CI workflow files",
+                message=(
+                    "Add the missing workflow files: "
+                    f"{', '.join(missing)}."
+                ),
+                path=missing[0],
+            ),
+        ]
+
+
 GATE_REGISTRY: dict[str, type[Gate]] = {
     VG001RequiredFilesGate.id: VG001RequiredFilesGate,
     VG002ForbiddenDirectoriesGate.id: VG002ForbiddenDirectoriesGate,
     VG003BasicSecretScanGate.id: VG003BasicSecretScanGate,
+    VG004LicenseAndNoticesGate.id: VG004LicenseAndNoticesGate,
+    VG005RequiredWorkflowsGate.id: VG005RequiredWorkflowsGate,
 }
 
 

--- a/policies/SCHEMA.md
+++ b/policies/SCHEMA.md
@@ -21,3 +21,19 @@ Each gate entry supports:
 - `exclude_paths: list[str]` (optional, overrides global for this gate)
 
 See: `policies/bundles/baseline/policy.yaml`.
+
+## Baseline gate config keys (v0.1)
+- `VG001`: no gate-specific config keys.
+- `VG002`:
+  - `forbidden: list[str]`
+  - `allow: list[str]`
+- `VG003`:
+  - `allow_paths: list[str]`
+  - `allow_patterns: list[str]`
+- `VG004`:
+  - `require_license: bool` (default `true`)
+  - `require_third_party_notices: bool` (default `false`)
+  - `license_paths: list[str]` (default `['LICENSE', 'LICENSE.md', 'LICENSE.txt']`)
+  - `notices_paths: list[str]` (default `['THIRD_PARTY_NOTICES.md', 'THIRD_PARTY_NOTICES.txt']`)
+- `VG005`:
+  - `required_workflows: list[str]` (default `['.github/workflows/verify.yml']`)

--- a/policies/bundles/baseline/policy.yaml
+++ b/policies/bundles/baseline/policy.yaml
@@ -34,6 +34,23 @@
         "allow_paths": [],
         "allow_patterns": []
       }
+    },
+    {
+      "id": "VG004",
+      "enabled": true,
+      "config": {
+        "require_license": true,
+        "require_third_party_notices": false,
+        "license_paths": ["LICENSE", "LICENSE.md", "LICENSE.txt"],
+        "notices_paths": ["THIRD_PARTY_NOTICES.md", "THIRD_PARTY_NOTICES.txt"]
+      }
+    },
+    {
+      "id": "VG005",
+      "enabled": true,
+      "config": {
+        "required_workflows": [".github/workflows/verify.yml"]
+      }
     }
   ]
 }

--- a/spec/GATES.md
+++ b/spec/GATES.md
@@ -40,6 +40,50 @@ Config:
 
 Findings are `high` severity and include path + pattern name, never the secret value.
 
+### VG004 — License / Third-Party Notices
+Checks for repository licensing and optional third-party notices files.
+
+Defaults:
+- License required
+- Third-party notices optional
+
+Config:
+- `require_license: bool` (default `true`)
+- `require_third_party_notices: bool` (default `false`)
+- `license_paths: list[str]` (default `['LICENSE', 'LICENSE.md', 'LICENSE.txt']`)
+- `notices_paths: list[str]` (default `['THIRD_PARTY_NOTICES.md', 'THIRD_PARTY_NOTICES.txt']`)
+
+Example:
+```json
+{
+  "id": "VG004",
+  "enabled": true,
+  "config": {
+    "require_license": true,
+    "require_third_party_notices": false,
+    "license_paths": ["LICENSE", "LICENSE.md", "LICENSE.txt"],
+    "notices_paths": ["THIRD_PARTY_NOTICES.md", "THIRD_PARTY_NOTICES.txt"]
+  }
+}
+```
+
+### VG005 — CI Workflow Presence
+Checks that required CI workflow files are present.
+
+Config:
+- `required_workflows: list[str]` (default `['.github/workflows/verify.yml']`)
+
+Example:
+```json
+{
+  "id": "VG005",
+  "enabled": true,
+  "config": {
+    "required_workflows": [".github/workflows/verify.yml"]
+  }
+}
+```
+
 ## Scope filters
 Policy supports global scope filters and per-gate overrides:
 - `include_paths: list[str]` optional glob allowlist


### PR DESCRIPTION
### Motivation
- Enforce baseline repository hygiene by ensuring projects include a license and that CI verification workflows exist, with policy-driven configuration for real-world flexibility.
- Add deterministic, fail-closed checks so baseline policy bundles can require these artifacts and produce clear remediation guidance when missing.

### Description
- Added two new gates in `packages/gates/registry.py`: `VG004` (`VG004LicenseAndNoticesGate`) to validate license and third-party notices presence, and `VG005` (`VG005RequiredWorkflowsGate`) to validate required CI workflow files, and registered them in `GATE_REGISTRY`.
- Implemented gate-level config defaults and overrides: `require_license`, `require_third_party_notices`, `license_paths`, `notices_paths`, and `required_workflows`.
- Added tests `apps/cli/tests/test_vg004_vg005.py` covering pass/fail cases, config overrides, and deterministic finding ordering, and updated existing test fixtures in `apps/cli/tests/test_gate_runner.py` and `apps/cli/tests/test_cli_check.py` to include a `LICENSE` and `.github/workflows/verify.yml` for baseline success scenarios.
- Updated baseline policy bundle `policies/bundles/baseline/policy.yaml` to enable `VG004` and `VG005` after `VG003`, and documented new gate configs in `policies/SCHEMA.md` and `spec/GATES.md` with examples.

### Testing
- Ran `python -m pre_commit run --all-files` and received `All checks passed!` indicating hooks passed.
- Ran `pytest -q` and received `35 passed in 0.14s`, confirming unit tests (including new VG004/VG005 tests) all passed.
- Ran `make verify` which ran pre-commit and tests and completed successfully reporting `All checks passed!` and `35 passed`.
- Attempted repository synchronization (`git fetch origin && git rebase origin/main`) but it failed in this environment with `fatal: 'origin' does not appear to be a git repository`, so the branch could not be rebased against a remote here.
- Local Git state and quick proofs: `git status` -> `On branch feat/vg004-vg005\nnothing to commit, working tree clean`; `git log -1 --oneline` -> `d26840a Implement VG004/VG005 baseline gates`; `git diff --stat origin/main...HEAD` failed locally with `fatal: ambiguous argument 'origin/main...HEAD'` for the same missing-remote reason.
- PR was created with title `v0.1: VG004 license check + VG005 CI workflow presence` via the repository integration, but no external PR URL is available from this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a51e00dbc483269a109d289a5a4ab2)