### PR TITLE
v0.1: audit pack exporter with manifest + hashing + metadata

### DIFF
--- a/apps/cli/tests/test_audit_pack.py
+++ b/apps/cli/tests/test_audit_pack.py
@@ -1,0 +1,129 @@
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from packages.core.policy_loader import load_policy_bundle
+from packages.gates.runner import run_gates
+from packages.reporting.audit_pack import create_audit_pack
+
+from vibeguard_cli.main import main
+
+POLICY_PATH = Path("policies/bundles/baseline/policy.yaml")
+
+
+def _write_required_files(repo: Path) -> None:
+    for file_name in ["README.md", "SECURITY.md", "ARCHITECTURE.md", "AGENTS.md", "ISSUE_ORDER.md"]:
+        (repo / file_name).write_text("ok\n", encoding="utf-8")
+    (repo / "LICENSE").write_text("MIT\n", encoding="utf-8")
+    workflow_dir = repo / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    (workflow_dir / "verify.yml").write_text("name: verify\n", encoding="utf-8")
+
+
+def _run_report(repo: Path):
+    policy_bundle = load_policy_bundle(POLICY_PATH)
+    return run_gates(policy=policy_bundle, repo_path=repo)
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def test_audit_pack_structure_created(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_required_files(repo)
+
+    report = _run_report(repo)
+    out_dir = tmp_path / "audit-pack"
+    run_dir = create_audit_pack(
+        repo_path=repo,
+        policy_path=POLICY_PATH,
+        findings_report=report,
+        out_dir=out_dir,
+        run_id="20260302T052130Z-testsha",
+        created_at=datetime(2026, 3, 2, 5, 21, 30, tzinfo=timezone.utc),  # noqa: UP017
+    )
+
+    assert run_dir == out_dir / "20260302T052130Z-testsha"
+    assert (run_dir / "manifest.json").is_file()
+    assert (run_dir / "reports" / "findings.json").is_file()
+    assert (run_dir / "reports" / "summary.md").is_file()
+    assert (run_dir / "policy_bundle" / "policy.yaml").is_file()
+    assert (run_dir / "evidence").is_dir()
+
+
+def test_manifest_fields_and_hashes(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_required_files(repo)
+
+    report = _run_report(repo)
+    run_dir = create_audit_pack(
+        repo_path=repo,
+        policy_path=POLICY_PATH,
+        findings_report=report,
+        out_dir=tmp_path / "audit-pack",
+        run_id="20260302T052130Z-fixed",
+        created_at=datetime(2026, 3, 2, 5, 21, 30, tzinfo=timezone.utc),  # noqa: UP017
+    )
+
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["run_id"] == "20260302T052130Z-fixed"
+    assert manifest["repo_path"] == str(repo)
+    assert manifest["policy_path"] == str(POLICY_PATH)
+    assert manifest["python_version"]
+    assert manifest["platform"]
+    assert manifest["os"]
+
+    file_entries = manifest["files"]
+    paths = [item["path"] for item in file_entries]
+    assert paths == sorted(paths)
+
+    entries_by_path = {item["path"]: item for item in file_entries}
+    findings_bytes = (run_dir / "reports" / "findings.json").read_bytes()
+    policy_bytes = (run_dir / "policy_bundle" / "policy.yaml").read_bytes()
+
+    assert entries_by_path["reports/findings.json"]["sha256"] == _sha256(findings_bytes)
+    assert entries_by_path["reports/findings.json"]["size_bytes"] == len(findings_bytes)
+    assert entries_by_path["policy_bundle/policy.yaml"]["sha256"] == _sha256(policy_bytes)
+    assert entries_by_path["policy_bundle/policy.yaml"]["size_bytes"] == len(policy_bytes)
+
+
+def test_policy_snapshot_matches_input_policy(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_required_files(repo)
+
+    report = _run_report(repo)
+    run_dir = create_audit_pack(
+        repo_path=repo,
+        policy_path=POLICY_PATH,
+        findings_report=report,
+        out_dir=tmp_path / "audit-pack",
+        run_id="20260302T052130Z-policy",
+        created_at=datetime(2026, 3, 2, 5, 21, 30, tzinfo=timezone.utc),  # noqa: UP017
+    )
+
+    snapshot = (run_dir / "policy_bundle" / "policy.yaml").read_text(encoding="utf-8")
+    assert snapshot == POLICY_PATH.read_text(encoding="utf-8")
+
+
+def test_cli_writes_pack_even_when_failing(tmp_path: Path, capsys) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    out_dir = tmp_path / "audit-pack"
+    exit_code = main(
+        ["audit-pack", str(repo), "--policy", str(POLICY_PATH), "--out-dir", str(out_dir)],
+    )
+    assert exit_code != 0
+
+    printed_path = capsys.readouterr().out.strip()
+    run_dir = Path(printed_path)
+    assert run_dir.exists()
+
+    findings = json.loads((run_dir / "reports" / "findings.json").read_text(encoding="utf-8"))
+    assert findings["summary"]["overall_status"] == "fail"
+    assert (run_dir / "reports" / "summary.md").is_file()

--- a/apps/cli/tests/test_cli_check.py
+++ b/apps/cli/tests/test_cli_check.py
@@ -27,17 +27,3 @@ def test_check_outputs_findings_json(tmp_path: Path, capsys) -> None:
     assert payload["summary"]["overall_status"] == "pass"
     assert payload["findings"] == []
 
-
-def test_audit_pack_writes_policy_snapshot(tmp_path: Path) -> None:
-    from vibeguard_cli.main import run_audit_pack
-
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _write_required_files(repo)
-
-    out_dir = tmp_path / "audit"
-    exit_code = run_audit_pack(repo, Path("policies/bundles/baseline/policy.yaml"), out_dir=out_dir)
-
-    assert exit_code == 0
-    assert (out_dir / "reports" / "findings.json").is_file()
-    assert (out_dir / "policy_bundle" / "policy.yaml").is_file()

--- a/apps/cli/vibeguard_cli/main.py
+++ b/apps/cli/vibeguard_cli/main.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from packages.core.policy_loader import PolicyLoadError, load_policy_bundle
 from packages.gates.runner import run_gates
+from packages.reporting.audit_pack import create_audit_pack
 
 DEFAULT_POLICY_PATH = Path("policies/bundles/baseline/policy.yaml")
 DEFAULT_AUDIT_OUT_DIR = Path("out/audit-pack")
@@ -32,24 +33,15 @@ def run_check(repo: Path, policy: Path, out: Path | None = None) -> int:
 def run_audit_pack(repo: Path, policy: Path, out_dir: Path = DEFAULT_AUDIT_OUT_DIR) -> int:
     _validate_repo(repo)
     policy_bundle = load_policy_bundle(policy)
-
-    (out_dir / "reports").mkdir(parents=True, exist_ok=True)
-    (out_dir / "evidence").mkdir(parents=True, exist_ok=True)
-    (out_dir / "policy_bundle").mkdir(parents=True, exist_ok=True)
-
     report = run_gates(policy=policy_bundle, repo_path=repo)
-
-    (out_dir / "reports" / "findings.json").write_text(report.to_json(), encoding="utf-8")
-    (out_dir / "reports" / "summary.md").write_text(
-        "# VibeGuard Audit Pack\n\nStub.\n",
-        encoding="utf-8",
+    run_dir = create_audit_pack(
+        repo_path=repo,
+        policy_path=policy,
+        findings_report=report,
+        out_dir=out_dir,
     )
-    (out_dir / "policy_bundle" / "policy.yaml").write_text(
-        policy.read_text(encoding="utf-8"),
-        encoding="utf-8",
-    )
-    print(str(out_dir))
-    return 0
+    print(str(run_dir))
+    return 0 if report.summary.overall_status == "pass" else 1
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/packages/reporting/__init__.py
+++ b/packages/reporting/__init__.py
@@ -1,5 +1,14 @@
 """Findings report models and serialization helpers."""
 
+from .audit_pack import create_audit_pack, sha256_file, write_manifest
 from .findings import Finding, FindingsReport, RunMetadata, Summary
 
-__all__ = ["Finding", "FindingsReport", "RunMetadata", "Summary"]
+__all__ = [
+    "Finding",
+    "FindingsReport",
+    "RunMetadata",
+    "Summary",
+    "create_audit_pack",
+    "sha256_file",
+    "write_manifest",
+]

--- a/packages/reporting/audit_pack.py
+++ b/packages/reporting/audit_pack.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from packages.reporting.findings import FindingsReport
+
+SEVERITY_ORDER = ["critical", "high", "medium", "low"]
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)  # noqa: UP017
+
+
+def _format_created_at(ts: datetime) -> str:
+    return ts.replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _git_sha(repo_path: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "rev-parse", "--short=7", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+def _build_run_id(created_at: datetime, git_sha: str | None) -> str:
+    timestamp = created_at.strftime("%Y%m%dT%H%M%SZ")
+    return f"{timestamp}-{git_sha or 'nogit'}"
+
+
+def _severity_counts(findings_report: FindingsReport) -> dict[str, int]:
+    counts = {severity: 0 for severity in SEVERITY_ORDER}
+    for finding in findings_report.findings:
+        if finding.severity in counts:
+            counts[finding.severity] += 1
+    return counts
+
+
+def _write_summary(
+    summary_path: Path,
+    run_id: str,
+    findings_report: FindingsReport,
+) -> None:
+    severity_counts = _severity_counts(findings_report)
+    lines = [
+        "# VibeGuard Audit Pack Summary",
+        "",
+        f"- run_id: {run_id}",
+        f"- overall_status: {findings_report.summary.overall_status}",
+        f"- policy_id: {findings_report.run.policy_id}",
+        f"- policy_version: {findings_report.run.policy_version}",
+        "",
+        "## Findings by severity",
+        "",
+    ]
+    lines.extend(f"- {severity}: {severity_counts[severity]}" for severity in SEVERITY_ORDER)
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _collect_hashed_files(run_dir: Path) -> list[dict[str, Any]]:
+    files: list[dict[str, Any]] = []
+    for path in sorted(run_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        rel_path = path.relative_to(run_dir).as_posix()
+        if rel_path == "manifest.json":
+            continue
+        files.append(
+            {
+                "path": rel_path,
+                "sha256": sha256_file(path),
+                "size_bytes": path.stat().st_size,
+            },
+        )
+    return files
+
+
+def write_manifest(
+    manifest_path: Path,
+    *,
+    vibeguard_version: str,
+    created_at_utc: str,
+    run_id: str,
+    repo_path: Path,
+    git_commit: str | None,
+    policy_path: Path,
+    overall_status: str,
+    files: list[dict[str, Any]],
+) -> None:
+    manifest = {
+        "vibeguard_version": vibeguard_version,
+        "created_at_utc": created_at_utc,
+        "run_id": run_id,
+        "repo_path": str(repo_path),
+        "git_commit": git_commit,
+        "policy_path": str(policy_path),
+        "overall_status": overall_status,
+        "python_version": sys.version.split()[0],
+        "platform": sys.platform,
+        "os": platform.platform(),
+        "files": files,
+    }
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def create_audit_pack(
+    repo_path: Path,
+    policy_path: Path,
+    findings_report: FindingsReport,
+    out_dir: Path,
+    *,
+    run_id: str | None = None,
+    created_at: datetime | None = None,
+    vibeguard_version: str = "0.1.0",
+) -> Path:
+    created = created_at or _utc_now()
+    git_sha = _git_sha(repo_path)
+    resolved_run_id = run_id or _build_run_id(created, git_sha)
+    run_dir = out_dir / resolved_run_id
+
+    reports_dir = run_dir / "reports"
+    evidence_dir = run_dir / "evidence"
+    policy_bundle_dir = run_dir / "policy_bundle"
+    reports_dir.mkdir(parents=True, exist_ok=False)
+    evidence_dir.mkdir(parents=True, exist_ok=False)
+    policy_bundle_dir.mkdir(parents=True, exist_ok=False)
+
+    findings_path = reports_dir / "findings.json"
+    summary_path = reports_dir / "summary.md"
+    policy_snapshot_path = policy_bundle_dir / "policy.yaml"
+    manifest_path = run_dir / "manifest.json"
+
+    findings_path.write_text(findings_report.to_json() + "\n", encoding="utf-8")
+    _write_summary(summary_path, resolved_run_id, findings_report)
+    policy_snapshot_path.write_text(policy_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+    files = _collect_hashed_files(run_dir)
+    write_manifest(
+        manifest_path,
+        vibeguard_version=vibeguard_version,
+        created_at_utc=_format_created_at(created),
+        run_id=resolved_run_id,
+        repo_path=repo_path,
+        git_commit=git_sha,
+        policy_path=policy_path,
+        overall_status=findings_report.summary.overall_status,
+        files=files,
+    )
+
+    return run_dir


### PR DESCRIPTION
### Motivation
- Implement Issues #011–#013 to add a v0.1 audit-pack exporter that produces a deterministic, tamper-evident audit bundle for a repo run.

### Description
- Add `packages/reporting/audit_pack.py` with `create_audit_pack`, `sha256_file`, and `write_manifest` to produce run dirs `out/audit-pack/<run-id>/` containing `manifest.json`, `reports/findings.json`, `reports/summary.md`, `policy_bundle/policy.yaml`, and `evidence/`, where `run-id` is a UTC timestamp plus short git sha (or `nogit`).
- Manifest creation computes SHA-256 and size for all files in the pack (excluding `manifest.json`), includes deterministic file ordering, overall_status, vibeguard_version, created_at_utc, run_id, repo_path, git_commit, policy_path, python/platform/os metadata, and omits secrets.
- Update CLI `apps/cli/vibeguard_cli/main.py` so `vibeguard audit-pack` runs gates, always writes the audit pack via `create_audit_pack`, prints the pack path, and returns non-zero when overall status is `fail`.
- Export audit-pack helpers from `packages/reporting/__init__.py` and add tests `apps/cli/tests/test_audit_pack.py` covering structure, manifest hashes, policy snapshot fidelity, and pack creation on failures; adjust `apps/cli/tests/test_cli_check.py` to remove an outdated assertion.

### Testing
- Ran `python -m pre_commit run --all-files` and received `All checks passed!`.
- Ran `pytest -q` and received `38 passed`.
- Ran `make verify` and received the pre-commit checks and tests passing (`All checks passed!` and `38 passed`).
- Git operations: created branch `feat/audit-pack-v01` and committed changes; attempted `git fetch origin && git rebase origin/main` but the environment has no configured `origin` remote (`fatal: 'origin' does not appear to be a git repository`), so remote rebase could not be performed here.
- Local git status is clean on `feat/audit-pack-v01` and commit recorded; CI/remote merge-conflict check should be done from a CI or a machine with `origin` configured before final merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a51f70a28883269108fe25e62716d5)