### PR TITLE
[#49] Publish reusable GitHub Action

### DIFF
--- a/.github/actions/vibeguard/action.yml
+++ b/.github/actions/vibeguard/action.yml
@@ -1,0 +1,34 @@
+name: VibeGuard Check
+description: Run vibeguard policy checks in CI.
+inputs:
+  policy_path:
+    description: Path to the VibeGuard policy bundle.
+    required: false
+    default: policies/bundles/baseline/policy.yaml
+  fail_on:
+    description: Minimum severity that fails the run.
+    required: false
+    default: high
+  format:
+    description: Output format for findings.
+    required: false
+    default: json
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements-dev.txt
+        pip install -e apps/cli
+
+    - name: Run VibeGuard check
+      shell: bash
+      run: |
+        vibeguard check . --policy "${{ inputs.policy_path }}" --fail-on "${{ inputs.fail_on }}" --format "${{ inputs.format }}"

--- a/ISSUE_ORDER.md
+++ b/ISSUE_ORDER.md
@@ -67,5 +67,5 @@
    - Add clearer human-readable CLI summary output without breaking machine formats.
 8. #48 v0.2: vibeguard.yaml config support
    - Support repo-level defaults via an optional `vibeguard.yaml` config file.
-9. #49 v0.2: Publish a reusable GitHub Action
+9. #49 ✅ v0.2: Publish a reusable GitHub Action (PR #TBD)
    - Package VibeGuard as a reusable action for adoption in external repos.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Manifest/hashing overview:
 ## CI behavior
 
 PR CI is defined in `.github/workflows/verify.yml` and currently runs:
+GitHub Action usage docs for external repos: [`docs/GITHUB_ACTION.md`](docs/GITHUB_ACTION.md).
+
 - Python 3.11 setup
 - dependency install (`requirements-dev.txt` + editable CLI install)
 - `make verify` (pre-commit + tests)

--- a/apps/cli/tests/test_github_action_docs.py
+++ b/apps/cli/tests/test_github_action_docs.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+def test_reusable_action_and_docs_exist() -> None:
+    action_path = Path('.github/actions/vibeguard/action.yml')
+    docs_path = Path('docs/GITHUB_ACTION.md')
+
+    assert action_path.exists()
+    assert docs_path.exists()
+
+    action_text = action_path.read_text(encoding='utf-8')
+    assert 'using: composite' in action_text
+    assert 'policy_path' in action_text
+    assert 'fail_on' in action_text
+    assert 'format' in action_text
+
+    docs_text = docs_path.read_text(encoding='utf-8')
+    assert 'uses: nvrenuf/vibeguard/.github/actions/vibeguard@<tag-or-sha>' in docs_text

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -1,0 +1,34 @@
+# Reusable GitHub Action
+
+VibeGuard ships an in-repo reusable composite action at:
+
+- `.github/actions/vibeguard/action.yml`
+
+Use it from another repository with:
+
+```yaml
+name: vibeguard
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  vibeguard-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run VibeGuard
+        uses: nvrenuf/vibeguard/.github/actions/vibeguard@<tag-or-sha>
+        with:
+          policy_path: policies/bundles/baseline/policy.yaml
+          fail_on: high
+          format: json
+```
+
+## Inputs
+
+- `policy_path` (default: `policies/bundles/baseline/policy.yaml`)
+- `fail_on` (default: `high`)
+- `format` (default: `json`)


### PR DESCRIPTION
### Motivation
- Provide an in-repo, reusable GitHub Action so external repositories can run VibeGuard checks with configurable inputs and minimal wiring.
- Keep docs and CI aligned by documenting usage and linking the README to the action docs.
- Update backlog tracking to mark this work as completed pending PR number; CI must remain green after the change. Closes #49

### Description
- Add a composite reusable action at `.github/actions/vibeguard/action.yml` with inputs `policy_path` (default `policies/bundles/baseline/policy.yaml`), `fail_on` (default `high`), and `format` (default `json`), which sets up Python 3.12, installs dev dependencies and the editable CLI, then runs `vibeguard check` wired to the inputs.
- Add `docs/GITHUB_ACTION.md` with a copy/paste workflow example using `uses: nvrenuf/vibeguard/.github/actions/vibeguard@<tag-or-sha>` and list of inputs.
- Update `README.md` CI section to link `docs/GITHUB_ACTION.md`.
- Add a lightweight unit test `apps/cli/tests/test_github_action_docs.py` verifying the action and docs exist and contain the expected references.
- Update `ISSUE_ORDER.md` v0.2 to mark `#49` as `✅ (PR #TBD)` so the PR can be updated with the real PR number before merge.

### Testing
- `pre-commit run --all-files` passed; output:
```text
All checks passed!
```
- `make verify` passed and all tests succeeded; output:
```text
Running pre-commit checks...
All checks passed!
Running tests...
make[1]: Entering directory '/workspace/vibeguard'
...................................................                      [100%]
51 passed in 0.35s
make[1]: Leaving directory '/workspace/vibeguard'
```
- `vibeguard check . --policy policies/bundles/baseline/policy.yaml` ran successfully and returned a passing run (no findings); output:
```json
{
  "findings": [],
  "run": {
    "generated_at": "2026-03-02T07:35:52.243122+00:00",
    "policy_id": "baseline",
    "policy_version": "0.1.0",
    "repo": "."
  },
  "schema_version": "1.0",
  "summary": {
    "overall_status": "pass",
    "total_findings": 0
  }
}
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a53d6c660c832684222b068bf8f053)